### PR TITLE
Ensure sidebar collapsed by default on mobile

### DIFF
--- a/assets/viewer.js
+++ b/assets/viewer.js
@@ -215,10 +215,14 @@ function scheduleRerender(){
     setTimeout(()=>{ forceFullRerender(true); scrollToPage(currentPage); }, 120); // late pass
   }
   // start collapsed by default so sidebar stays closed on first load, especially on mobile
-  let collapsed=true;
+  let collapsed = true;
   try {
-    const saved=localStorage.getItem('pdfv_sidebar');
-    if(saved!==null) collapsed = (saved==='1');
+    const saved = localStorage.getItem('pdfv_sidebar');
+    // Only respect the saved state on wider screens so the sidebar doesn't
+    // cover the document on mobile devices.
+    if (saved !== null && window.matchMedia('(min-width: 768px)').matches) {
+      collapsed = (saved === '1');
+    }
   } catch {}
   // apply initial (does nothing harmful before pages exist)
   apply(collapsed);


### PR DESCRIPTION
## Summary
- Respect saved sidebar preference only on wide screens so mobile always starts collapsed

## Testing
- `node --check assets/viewer.js`


------
https://chatgpt.com/codex/tasks/task_e_68aeeca502c48327a60ff49e714fceb9