### PR TITLE
Handle mobile sidebar backdrop via viewer script

### DIFF
--- a/assets/viewer.js
+++ b/assets/viewer.js
@@ -20,6 +20,7 @@ const els = {
   zoomOut: $('zoomOut'),
   zoomSelect: $('zoomSelect'),
   fullscreenBtn: $('fullscreenBtn'),
+  drawerBackdrop: $('drawerBackdrop'),
 };
 
 // ----- state -----
@@ -205,6 +206,7 @@ function scheduleRerender(){
 // ----- sidebar toggle (fixed flow) -----
 (function initSidebarToggle(){
   const shell=document.querySelector('.shell');
+  const backdrop=els.drawerBackdrop;
   async function apply(collapsed){
     shell.classList.toggle('collapsed', collapsed);
     els.toggleSidebar.setAttribute('aria-pressed', (!collapsed).toString());
@@ -227,6 +229,7 @@ function scheduleRerender(){
   // apply initial (does nothing harmful before pages exist)
   apply(collapsed);
   els.toggleSidebar.addEventListener('click', ()=> apply(!shell.classList.contains('collapsed')));
+  backdrop?.addEventListener('click', ()=> apply(true));
 })();
 
 // ----- wiring -----

--- a/view.php
+++ b/view.php
@@ -462,9 +462,6 @@ $token = token_for($link['id'], $link['doc_id']);
       menu.classList.remove('show');
     });
 
-    // Backdrop click closes drawer on mobile
-    document.getElementById('drawerBackdrop')
-      .addEventListener('click', ()=> document.querySelector('.shell').classList.add('collapsed'));
   })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- handle mobile drawer backdrop inside `viewer.js` so closing the sidebar triggers a rerender
- drop inline backdrop handler from `view.php`

## Testing
- `php -l view.php`
- `node --check assets/viewer.js`


------
https://chatgpt.com/codex/tasks/task_e_68aeedc7e83883278f4ecf9964ab66bd