### PR TITLE
feat: add mobile fallback for PDF viewer

### DIFF
--- a/view.php
+++ b/view.php
@@ -17,6 +17,25 @@ if (!$link) { http_response_code(404); exit('Link not found'); }
 if ((int)$link['allow_view'] !== 1) { http_response_code(403); exit('Viewing disabled'); }
 
 $token = token_for($link['id'], $link['doc_id']);
+
+// Simple iframe fallback for mobile browsers
+$isMobile = isset($_SERVER['HTTP_USER_AGENT']) && preg_match('/Mobile|Android|iP(hone|od|ad)/i', $_SERVER['HTTP_USER_AGENT']);
+if ($isMobile) {
+  ?>
+  <!doctype html>
+  <html lang="en">
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"/>
+    <title><?= htmlspecialchars($link['original_name']) ?></title>
+  </head>
+  <body style="margin:0">
+    <iframe src="<?= APP_BASE_URL ?>/api/pdf.php?tok=<?= urlencode($token) ?>" style="border:0;width:100%;height:100vh;"></iframe>
+  </body>
+  </html>
+  <?php
+  exit;
+}
 ?>
 <!doctype html>
 <html lang="en">


### PR DESCRIPTION
## Summary
- add server-side detection of mobile user agents and serve PDF via iframe fallback
- keep existing advanced viewer for desktop

## Testing
- `php -l view.php`


------
https://chatgpt.com/codex/tasks/task_e_68aef660ab008327937e67c37f2fde05