### PR TITLE
Improve validation and mobile PDF handling

### DIFF
--- a/list.php
+++ b/list.php
@@ -79,10 +79,15 @@ $docs = db_all("SELECT * FROM documents WHERE user_id=? ORDER BY id DESC", [$use
 document.getElementById('uploadForm').addEventListener('submit', async function(e){
   e.preventDefault();
   if(!this.pdf.files.length){ alert('Please select a PDF file.'); return; }
+  const file=this.pdf.files[0];
+  if(file.type!=='application/pdf'){ alert('Only PDF allowed'); return; }
+  if(file.size>50*1024*1024){ alert('File too large (>50MB)'); return; }
   const fd=new FormData(this);
   const resp=await fetch(this.action,{method:'POST',body:fd});
-  if(resp.ok){ location.reload(); }
-  else{ alert('Upload failed'); }
+  let data=null;
+  try{ data=await resp.json(); }catch{}
+  if(resp.ok && data && data.ok){ location.reload(); }
+  else{ alert(data?.error || 'Upload failed'); }
 });
 
 // link creation forms via AJAX
@@ -92,8 +97,9 @@ document.querySelectorAll('.ajax-form').forEach(f=>{
     const fd=new FormData(f);
     if(!/^\d+$/.test(fd.get('doc_id'))){ alert('Invalid document'); return; }
     const resp=await fetch(f.action,{method:'POST',body:fd});
-    if(!resp.ok){ alert('Server error'); return; }
-    const data=await resp.json();
+    let data=null;
+    try{ data=await resp.json(); }catch{}
+    if(!resp.ok || data.error){ alert(data?.error || 'Server error'); return; }
     let html='<p><a href="'+data.url+'" target="_blank">'+data.url+'</a></p>';
     if(data.embed){ html+='<textarea class="form-control">'+data.embed+'</textarea>'; }
     document.getElementById('linkResult').innerHTML=html;

--- a/upload.php
+++ b/upload.php
@@ -4,18 +4,26 @@ require_once __DIR__.'/db.php';
 require_once __DIR__.'/helpers.php';
 require_once __DIR__.'/auth_mock.php';
 license_check();
-if($_SERVER['REQUEST_METHOD']!=='POST') { http_response_code(405); exit; }
+header('Content-Type: application/json');
+
+function fail($code, $msg){
+  http_response_code($code);
+  echo json_encode(['error'=>$msg]);
+  exit;
+}
+
+if($_SERVER['REQUEST_METHOD']!=='POST') { fail(405,'Method not allowed'); }
 
 $userId = current_user_id();
 $slug = current_user_folder_slug();
 
-if(empty($_FILES['pdf']['name'])){ http_response_code(400); exit('No file'); }
-if($_FILES['pdf']['error']!==UPLOAD_ERR_OK){ http_response_code(400); exit('Upload error'); }
-if($_FILES['pdf']['size'] > 50*1024*1024){ http_response_code(413); exit('File too large (>50MB)'); }
+if(empty($_FILES['pdf']['name'])){ fail(400,'No file'); }
+if($_FILES['pdf']['error']!==UPLOAD_ERR_OK){ fail(400,'Upload error'); }
+if($_FILES['pdf']['size'] > 50*1024*1024){ fail(413,'File too large (>50MB)'); }
 
 $finfo = finfo_open(FILEINFO_MIME_TYPE);
 $mime  = finfo_file($finfo, $_FILES['pdf']['tmp_name']);
-if($mime!=='application/pdf'){ http_response_code(400); exit('Only PDF'); }
+if($mime!=='application/pdf'){ fail(400,'Only PDF allowed'); }
 
 $orig = $_FILES['pdf']['name'];
 $store = time().'_'.bin2hex(random_bytes(4)).'.pdf';
@@ -28,5 +36,4 @@ $sha = hash_file('sha256', $dest);
 db_exec("INSERT INTO documents(user_id,filename,original_name,size_bytes,mime,sha256) VALUES(?,?,?,?,?,?)",
   [$userId,$store,$orig,$_FILES['pdf']['size'],$mime,$sha]);
 
-header('Content-Type: application/json');
 echo json_encode(['ok'=>true]);

--- a/view.php
+++ b/view.php
@@ -17,13 +17,6 @@ if (!$link) { http_response_code(404); exit('Link not found'); }
 if ((int)$link['allow_view'] !== 1) { http_response_code(403); exit('Viewing disabled'); }
 
 $token = token_for($link['id'], $link['doc_id']);
-
-// On mobile devices open the PDF directly using the browser's native viewer.
-$isMobile = isset($_SERVER['HTTP_USER_AGENT']) && preg_match('/Mobile|Android|iP(hone|od|ad)/i', $_SERVER['HTTP_USER_AGENT']);
-if ($isMobile) {
-  header('Location: ' . APP_BASE_URL . '/api/pdf.php?tok=' . urlencode($token));
-  exit;
-}
 ?>
 <!doctype html>
 <html lang="en">


### PR DESCRIPTION
## Summary
- add JSON error responses and helper fail functions for upload and link generation
- enhance client-side file validation and error handling for AJAX forms
- remove mobile redirect so viewer works consistently across devices

## Testing
- `php -l upload.php`
- `php -l link_create.php`
- `php -l view.php`
- `php -l list.php`
- `php -l app/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68aefa53d88083279721df08f018569d