### PR TITLE
Fix PDF viewer scrolling issue

### DIFF
--- a/resources/views/docs/viewer.blade.php
+++ b/resources/views/docs/viewer.blade.php
@@ -186,15 +186,17 @@
     }
 
     .main{
-      display:grid; 
-      grid-template-rows:1fr auto; 
+      display:grid;
+      grid-template-rows:1fr auto;
       min-width:0;
+      min-height:0;
       position: relative;
     }
     .canvas-wrap{
       overflow:auto;
       padding:20px;
       position: relative;
+      height:100%;
     }
     #pdfContainer{
       display:flex;


### PR DESCRIPTION
## Summary
- Ensure main viewer area can scroll by setting min-height for grid container
- Force canvas wrapper to fill available space so all PDF pages render

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af5d68327083279de65dcf9db1c764