### PR TITLE
Improve PDF viewer integration and validation

### DIFF
--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -132,7 +132,7 @@ class DocumentController extends Controller
         return response()->json([
             'view_url'         => route('documents.viewer', ['id' => $doc->id, 's' => $link->slug]),
             'download_allowed' => (bool) $link->allow_download,
-            'expires_at'       => $link->expires_at?->toIso8601String(),
+            'expires_at'       => $link->expires_at?->format('d-m-Y'),
         ]);
     }
 
@@ -140,7 +140,8 @@ class DocumentController extends Controller
     public function upload(Request $request)
     {
         $request->validate([
-            'file' => 'required|mimetypes:application/pdf|file|max:51200', // 50MB
+            'file'          => 'required|mimetypes:application/pdf|file|max:51200', // 50MB
+            'allow_download'=> 'sometimes|boolean',
         ]);
 
         $file = $request->file('file');

--- a/resources/views/docs/uploader.blade.php
+++ b/resources/views/docs/uploader.blade.php
@@ -85,10 +85,18 @@
       const formData = new FormData(e.target);
       const res = await fetch(e.target.action, {
         method: 'POST',
-        headers: { 'X-CSRF-TOKEN': csrfToken },
+        headers: {
+          'X-CSRF-TOKEN': csrfToken,
+          'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest'
+        },
         body: formData
       });
       const data = await res.json();
+      if (!res.ok) {
+        alert(Object.values(data.errors || { error: 'Upload failed' })[0]);
+        return;
+      }
       document.getElementById('uploadResult').textContent = JSON.stringify(data, null, 2);
     });
 
@@ -115,10 +123,18 @@
 
       const res = await fetch(url, {
         method: 'POST',
-        headers: { 'X-CSRF-TOKEN': csrfToken },
+        headers: {
+          'X-CSRF-TOKEN': csrfToken,
+          'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest'
+        },
         body
       });
       const data = await res.json();
+      if (!res.ok) {
+        alert(Object.values(data.errors || { error: 'Link creation failed' })[0]);
+        return;
+      }
       document.getElementById('result').textContent = JSON.stringify(data, null, 2);
     });
   </script>

--- a/resources/views/docs/viewer.blade.php
+++ b/resources/views/docs/viewer.blade.php
@@ -11,6 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"/>
 
   <style>
     :root{


### PR DESCRIPTION
## Summary
- Load Bootstrap CSS on PDF viewer page so row/col/card layout renders as expected
- Improve uploader AJAX requests with JSON headers and error handling on both upload and link creation
- Validate uploads server-side for allow_download flag and return link expiry dates in dd-mm-yyyy format

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68af66cee7a083278ea8f7a2c8045ab2