### PR TITLE
docs: clarify pdf stream routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ php artisan migrate
 - Start your server: `php artisan serve`
 - Visit: `http://127.0.0.1:8000/docs`
   - Upload a PDF
-  - Create a link (set TTL=0 for never expire, toggle "Allow Download")
+  - Create a link (set TTL=0 for never expire, toggle "Allow Download"; expiry date uses dd-mm-yyyy format)
   - Open the `view_url` shown in results
   - If download is disabled, the ⬇ button is disabled and direct `download` route returns 403
 
@@ -30,8 +30,8 @@ php artisan migrate
 
 ## Endpoints
 - `GET /documents/{id}/view?s=TOKEN` → Viewer UI
-- `GET /documents/{id}/stream?s=TOKEN` → PDF bytes for pdf.js
-- `GET /documents/{id}/download?s=TOKEN` → Attachment (403 when not allowed)
+- `POST /documents/{id}/stream-data` (body: `s=TOKEN`, `nonce`) → PDF bytes for pdf.js
+- `POST /documents/{id}/download` (body: `s=TOKEN`) → Attachment (403 when not allowed)
 - `POST /documents/{id}/link` → JSON { view_url, stream_url, ... }
 - `POST /documents/upload` → Upload PDF (form on /docs adds CSRF automatically)
 

--- a/routes/pdf_viewer_routes.php
+++ b/routes/pdf_viewer_routes.php
@@ -10,9 +10,21 @@ Route::get('/docs', [DocumentController::class, 'uploaderForm'])->name('document
 Route::post('/documents/upload', [DocumentController::class, 'upload'])->name('documents.upload');
 
 // Viewer + stream + download
-Route::get('/documents/{id}/view', [DocumentController::class, 'viewer'])->name('documents.viewer');
-Route::get('/documents/{id}/stream', [DocumentController::class, 'stream'])->name('documents.stream');
-Route::get('/documents/{id}/download', [DocumentController::class, 'download'])->name('documents.download');
+Route::get('/documents/{id}/view', [DocumentController::class, 'viewer'])
+    ->name('documents.viewer');
+
+Route::post('/documents/{id}/stream-data', [DocumentController::class, 'streamData'])
+    ->name('documents.stream.data');
+Route::match(['GET', 'PUT', 'PATCH', 'DELETE'], '/documents/{id}/stream-data', function () {
+    abort(403, 'FORBIDDEN ACCESS');
+});
+
+Route::post('/documents/{id}/download', [DocumentController::class, 'download'])
+    ->name('documents.download');
+Route::match(['GET', 'PUT', 'PATCH', 'DELETE'], '/documents/{id}/download', function () {
+    abort(403, 'FORBIDDEN ACCESS');
+});
 
 // Create share link
 Route::post('/documents/{id}/link', [DocumentController::class, 'createLink'])->name('documents.link.create');
+


### PR DESCRIPTION
## Summary
- align sample routes with POST-only stream and download endpoints
- document new stream-data route and dd-mm-yyyy link expiry format

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68af692c75ec8327aeee262115f3eab8